### PR TITLE
Revert "chore(deps): update mongo docker tag to v4.4"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   #     - "27017:27017"
 
   mongo:
-    image: mongo:4.4
+    image: mongo:4.0
     command: --smallfiles
     ports:
       - "27017:27017"


### PR DESCRIPTION
Reverts eshork/go-mongoid#41

Shockingly, the prior change actually breaks the localdev test environment. Looks like the command line options to mongod have changed. See output:

```
go-mongoid % docker-compose up
Starting go-mongoid_mongo_1 ... done
Attaching to go-mongoid_mongo_1
mongo_1  | Error parsing command line: unrecognised option '--smallfiles'
mongo_1  | try 'mongod --help' for more information
go-mongoid_mongo_1 exited with code 2
```